### PR TITLE
Fixed scope where the DOM adapter is set

### DIFF
--- a/src/polymer-element.spec.ts
+++ b/src/polymer-element.spec.ts
@@ -10,6 +10,7 @@ import { TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing
 import { Component } from '@angular/core';
 import { ControlGroup, Control } from '@angular/common';
 import { By } from '@angular/platform-browser/src/dom/debug/by';
+import { __platform_browser_private__ } from '@angular/platform-browser';
 
 import {
 TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS,
@@ -276,6 +277,24 @@ describe('PolymerElement', () => {
         expect(observerSpy).toHaveBeenCalledTimes(1);
         done();
       }, 0);
+    });
+
+    it('should have the correct adapter', () => {
+      const functionName = (fun) => {
+        var ret = fun.toString();
+        ret = ret.substr('function '.length);
+        ret = ret.substr(0, ret.indexOf('('));
+        return ret;
+      };
+
+      var dom = __platform_browser_private__.getDOM();
+      const adapterName = functionName(dom.constructor);
+
+      if (Polymer.Settings.useShadow) {
+        expect(adapterName).toEqual("PolymerDomAdapter");
+      } else {
+        expect(adapterName).toEqual("PolymerShadyDomAdapter");
+      }
     });
 
   });

--- a/src/polymer-element.ts
+++ b/src/polymer-element.ts
@@ -14,7 +14,7 @@ import {
 import { NgControl, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/common';
 
 import { BrowserDomAdapter } from '@angular/platform-browser/src/browser/browser_adapter';
-import { setDOM } from '@angular/platform-browser/src/dom/dom_adapter';
+import { __platform_browser_private__ } from '@angular/platform-browser';
 
 const Polymer:any = (<any>window).Polymer;
 
@@ -61,9 +61,9 @@ class PolymerShadyDomAdapter extends PolymerDomAdapter {
 }
 
 if (Polymer.Settings.useShadow) {
-  setDOM(new PolymerDomAdapter());
+  __platform_browser_private__.setRootDomAdapter(new PolymerDomAdapter());
 } else {
-  setDOM(new PolymerShadyDomAdapter());
+  __platform_browser_private__.setRootDomAdapter(new PolymerShadyDomAdapter());
 }
 
 


### PR DESCRIPTION
If an Angular 2 app imports Angular 2 UMD bundles instead of the separate source files, using the imported setDOM from `@angular/platform-browser/src/dom/dom_adapter` to set the DOM adapter wouldn't do the trick; the adapter would end up in a wrong scope and the app would use the default one.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/angular2-polymer/44)

<!-- Reviewable:end -->
