### PR TITLE
Add asciidoc guide for using in Angular-CLI webpack applications

### DIFF
--- a/docs/ng-cli-webpack.adoc
+++ b/docs/ng-cli-webpack.adoc
@@ -1,0 +1,232 @@
+:linkattrs:
+[[vaadin-angular2-polymer.ng2cli]]
+= Using Polymer Elements in Angular-CLI Webpack Applications
+
+[[vaadin-angular2-polymer.ng2cli.introduction]]
+== Introduction
+
+https://github.com/angular/angular-cli[Angular-CLI] is a command line tool for Angular 2. It is not only a scaffolding tool for creating and modifying a project, but also for other actions like building, running, debugging, and testing the project.
+
+In this document we will describe all the modifications you have to make to your Angular-CLI project to use Polymer elements.
+
+[[vaadin-angular2-polymer.ng2cli.webpack-note]]
+[NOTE]
+.Note for the Angular-CLI SystemJS Version Users
+====
+If you are using the SystemJS version of the Angular-CLI tool, please follow the link:ng-cli.adoc[Using Polymer Elements in Angular-CLI SystemJS Applications] guide.
+====
+
+
+[[vaadin-angular2-polymer.ng2cli.preparation]]
+== Preparation
+
+Install the Angular-CLI in your system, and create a new Angular 2 project.
+
+[subs="normal"]
+----
+[prompt]#$# [command]#npm# install -g angular-cli@webpack
+[prompt]#$# [command]#ng# new [replaceable]#my-project#
+----
+
+Check that everything works by compiling, testing, and running your project:
+
+[subs="normal"]
+----
+[prompt]#$# [command]#cd# [replaceable]#my-project#
+[prompt]#$# [command]#ng# build
+[prompt]#$# [command]#ng# test
+[prompt]#$# [command]#ng# serve
+----
+
+After starting the `[prompt]#$# [command]#ng# serve` command, the development server should be running at http://localhost:4200[http://localhost:4200, role="external", window="_blank"]. Press kbd:[Ctrl+C] to stop the development server.
+
+[[vaadin-angular2-polymer.ng2cli.dependencies]]
+== Adding Polymer Elements Dependencies
+
+Polymer uses the http://bower.io/[Bower] package manager. Hence, you first  have to install and initialize Bower before continuing:
+
+[subs="normal"]
+----
+[prompt]#$# [command]#npm# install bower -g
+[prompt]#$# [command]#bower# init
+----
+
+By default, Bower installs dependencies to the [filename]#bower_components# folder. But Angular-CLI expects static stuff to be in the [filename]#public# directory. Thus, create the [filename]#.bowerrc# file in the root directory, with the following content:
+
+[source,json]
+.&#46;bowerrc
+----
+{
+  "directory" : "public/bower_components"
+}
+----
+
+Now, you can install all the Polymer elements that you need in your application.
+
+For instance, to install all the elements in the https://elements.polymer-project.org/browse?package=paper-elements[Polymer Paper] collection, and the [elementname]#https://vaadin.com/elements/-/element/vaadin-combo-box[vaadin-combo-box]# element, run the following:
+
+[subs="normal"]
+----
+[prompt]#$# [command]#bower# install --save [replaceable]#paper-elements vaadin-combo-box#
+----
+
+[TIP]
+.Ignore the Bower Dependencies in you Git Repository
+====
+Add the following line to the [filename]#.gitignore# file to prevent the Bower dependencies from being tracked by Git in future:
+
+[source]
+----
+public/bower_components
+----
+====
+
+Next we will modify the application index HTML file to load the web components polyfill and import the Polymer elements. Open the [filename]#src/index.html# file and append the following lines to the [elementname]#head# section:
+
+[source,html]
+.src/index.html head additions
+----
+<head>
+  ...
+
+  <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link rel="import" href="bower_components/paper-styles/color.html">
+  <link rel="import" href="bower_components/paper-styles/typography.html">
+  <link rel="import" href="bower_components/vaadin-combo-box/vaadin-combo-box.html">
+  <link rel="import" href="bower_components/paper-input/paper-input.html">
+</head>
+----
+
+In Angular-CLI Webpack projects, the main application file is automatically bundled and appended to the end of the [elementname]#body# section in the application’s [filename]#index.html# file. It means that the Angular application is imported and bootstrapped synchronously. Meanwhile, the Polymer elemnts are loaded from the HTML Imports, which are processed asynchronously in browsers that do not have a native support.
+
+In order to use Polymer elements from JavaScript with cross-browser support, we have to wait for the Polymer elements to be loaded and registered before running the application code. Therefore, we have to postpone the Angular application import after the [eventname]#WebComponentsReady# event is dispatched. Create a new file [filename]#src/main-polymer.ts# with the following loader script:
+
+[source,typescript]
+.src/main-polymer.ts
+----
+document.addEventListener('WebComponentsReady', function() {
+  require('./main.ts');
+});
+----
+
+In that file we wait until the Polymer elements are registered and load the original main file afterwards. Finally, we change the main entry point of the application to our loader script. Edit the [filename]#angular-cli.json# file in the project root, replace the line `"main": "main.ts",` with the line `"main": "main-polymer.ts",`, and save the file.
+
+////
+// TODO: `$ ng set` could be used for editing the config, but it is broken nowadays. Replace the editing instructions above with the following paragraph after this PR is merged: https://github.com/angular/angular-cli/pull/1800
+
+Finally, run the following command to modify the application configuration file to use the [filename]#src/main-polymer.ts# file as a main application entry point:
+
+[subs="normal"]
+----
+[prompt]#$# [command]#ng# set apps.0.main main-polymer.ts
+----
+////
+
+Now you can run `ng serve`, open the application in your browser, and everything should work with no errors in the console.
+
+[TIP]
+The [filename]#webcomponents.js# polyfill is not necessary for browsers that fully implement the Web Components Spec like Chrome.
+
+
+[[vaadin-angular2-polymer.ng2cli.directive]]
+== Adding The PolymerElement Package
+
+For using Polymer elements in the Angular 2 application, we need to import the [classname]#PolymerElement# directive from https://github.com/vaadin/angular2-polymer[@vaadin/angular2-polymer]. Thus we need to install the dependency by typing:
+
+[subs="normal"]
+----
+[prompt]#$# [command]#npm# install --save @vaadin/angular2-polymer
+----
+
+
+[[vaadin-angular2-polymer.ng2cli.using]]
+== Using Polymer Elements
+
+Now that everything is set, we can add any Polymer elements to our application using their element names in templates, and the [classname]#PolymerElement# directive in code.
+For example, modify the [filename]#src/app/app.component.html# to have the following code:
+
+[source,html]
+.src/app/app.component.html
+----
+<h3>{{title}}</h3>
+<vaadin-combo-box [label]="myLabel" [(value)]="myValue" [items]="myItems"></vaadin-combo-box>
+<paper-input [(value)]="myValue"></paper-input>
+----
+
+In the [filename]#src/app/app.component.ts# file, define the properties bound in the template and specify the initial values:
+
+[source,typescript]
+.src/app/app.component.ts
+----
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  title = 'app works!';
+  myLabel='Select a number'
+  myValue = '4';
+  myItems = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+}
+----
+
+Then import and add the [classname]#PolymerElement# directives and the [classname]#CUSTOM_ELEMENTS_SCHEMA# to the [classname]#AppModule#. Open the [filename]#src/app/app.module.ts# file and replace the contents with the following code:
+
+[source,typescript]
+.src/app/app.module.ts
+----
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+import { PolymerElement } from '@vaadin/angular2-polymer';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    PolymerElement('vaadin-combo-box'),
+    PolymerElement('paper-input')
+  ],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    HttpModule
+  ],
+  providers: [],
+  entryComponents: [AppComponent],
+  bootstrap: [AppComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+export class AppModule { }
+----
+
+Finally, you can use Polymer custom CSS properties and custom CSS mixins in the [filename]#app.component.ts# file for the scoped styles, and in the [filename]#index.html# file for the global ones.
+In the following example we use mixins and properties defined in the Paper [elementname]#color# and [elementname]#typography# elements.
+
+[source,html]
+.src/index.html
+----
+<head>
+  ...
+  <style is="custom-style">
+    body {
+      @apply(--paper-font-body1);
+    }
+  </style>
+</head>
+----
+
+[source,css]
+.src/app/app.component.css
+----
+paper-input,
+vaadin-combo-box {
+  background: var(--paper-grey-200);
+  padding: 8px;
+}
+----

--- a/docs/ng-cli.adoc
+++ b/docs/ng-cli.adoc
@@ -1,11 +1,11 @@
 ---
-title: Polymer in Angular-CLI Apps
+title: Using in Angular-CLI SystemJS Apps
 order: 3
 layout: page
 ---
 
 [[vaadin-angular2-polymer.ng2cli]]
-= Using Polymer Elements with Angular-CLI Apps
+= Using Polymer Elements in Angular-CLI SystemJS Applications
 
 [[vaadin-angular2-polymer.ng2cli.introduction]]
 == Introduction
@@ -13,6 +13,16 @@ layout: page
 https://github.com/angular/angular-cli[Angular-CLI] is a command line tool for Angular 2. It is not only a scaffolding tool for creating and modifying a project, but also for other actions like building, running, debugging, and testing the project.
 
 In this document we will describe all the modifications you have to make to your Angular-CLI project to use Polymer elements.
+
+////
+// TODO: Uncomment this paragraph after correcting the link below
+[[vaadin-angular2-polymer.ng2cli.webpack-note]]
+[NOTE]
+.Note for the Angular-CLI Webpack Version Users
+====
+If you are using the webpack version of the Angular-CLI tool, please use the link:ng-cli-webpack.adoc[Using Polymer Elements in Angular-CLI Webpack Applications] guide.
+====
+////
 
 
 [[vaadin-angular2-polymer.ng2cli.preparation]]


### PR DESCRIPTION
Note for reviewers: The Webpack Version of Angular-CLI is a pre-release. We should probably not publish the guide on vaadin.com/docs until it is an official stable release. Hence the webpack asciidoc guide doesn’t have the docs website header.

Fixes #21

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/angular2-polymer/65)

<!-- Reviewable:end -->
